### PR TITLE
Autocomplete

### DIFF
--- a/app.js
+++ b/app.js
@@ -56,6 +56,7 @@ app.get('/ask', require('./routes/ask.js'));
 app.get('/wat/:id', require('./routes/wat.js'));
 
 app.get('/search', require('./routes/search.js'));
+app.get('/searchpartial', require('./routes/searchpartial.js'));
 
 app.listen(port, address);
 

--- a/public/scripts/typeaheadajax.js
+++ b/public/scripts/typeaheadajax.js
@@ -1,0 +1,309 @@
+/* =============================================================
+ * bootstrap-typeahead.js v2.0.2
+ * http://twitter.github.com/bootstrap/javascript.html#typeahead
+ * =============================================================
+ * Copyright 2012 Twitter, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ============================================================ */
+
+!function( $ ){
+
+  "use strict"
+
+  var TypeaheadAjax = function ( element, options ) {
+    this.$element = $(element)
+    this.options = $.extend({}, $.fn.typeahead.defaults, options)
+    this.matcher = this.options.matcher || this.matcher
+    this.sorter = this.options.sorter || this.sorter
+    this.highlighter = this.options.highlighter || this.highlighter
+    this.$menu = $(this.options.menu).appendTo('body')
+    this.source = this.options.source
+    this.onselect = this.options.onselect
+    this.strings = true
+    this.shown = false
+    this.listen()
+  }
+
+  TypeaheadAjax.prototype = {
+
+    constructor: TypeaheadAjax
+
+  , select: function () {
+      var val = JSON.parse(this.$menu.find('.active').attr('data-value'))
+         , text
+    
+      if (!this.strings) text = val[this.options.property]
+      else text = val
+    
+      this.$element.val(text)
+      if (typeof this.onselect == "function")
+         this.onselect(val)
+
+      return this.hide()
+    }
+
+  , show: function () {
+      var pos = $.extend({}, this.$element.offset(), {
+        height: this.$element[0].offsetHeight
+      })
+
+      this.$menu.css({
+        top: pos.top + pos.height
+      , left: pos.left
+      })
+
+      this.$menu.show()
+      this.shown = true
+      return this
+    }
+
+  , hide: function () {
+      this.$menu.hide()
+      this.shown = false
+      return this
+    }
+
+  , lookup: function (event) {
+      var that = this
+        , items
+        , q
+        , value
+
+      this.query = this.$element.val()
+
+      if (typeof this.source == "function") 
+        value = this.source(this, this.query)
+        if (value)
+          this.process(value)
+      else 
+        this.process(this.source)
+    }
+
+  , process: function (results) {
+      var that = this
+        , items
+        , q
+
+      if (results.length && typeof results[0] != "string")
+          this.strings = false
+
+      this.query = this.$element.val()
+
+      if (!this.query) {
+        return this.shown ? this.hide() : this
+      }
+
+      items = $.grep(results, function (item) {
+        if (!that.strings)
+          item = item[that.options.property]
+        if (that.matcher(item)) return item
+      })
+
+      items = this.sorter(items)
+
+      if (!items.length) {
+        return this.shown ? this.hide() : this
+      }
+
+      return this.render(items.slice(0, this.options.items)).show()
+    }
+
+  , matcher: function (item) {
+      return ~item.toLowerCase().indexOf(this.query.toLowerCase())
+    }
+
+  , sorter: function (items) {
+      var beginswith = []
+        , caseSensitive = []
+        , caseInsensitive = []
+        , item
+        , sortby
+
+      while (item = items.shift()) {
+        if (this.strings) sortby = item
+        else sortby = item[this.options.property]
+
+        if (!sortby.toLowerCase().indexOf(this.query.toLowerCase())) beginswith.push(item)
+        else if (~sortby.indexOf(this.query)) caseSensitive.push(item)
+        else caseInsensitive.push(item)
+      }
+
+      return beginswith.concat(caseSensitive, caseInsensitive)
+    }
+
+  , highlighter: function (item) {
+      return item.replace(new RegExp('(' + this.query + ')', 'ig'), function ($1, match) {
+        return '<strong>' + match + '</strong>'
+      })
+    }
+
+  , render: function (items) {
+      var that = this
+
+      items = $(items).map(function (i, item) {
+        i = $(that.options.item).attr('data-value', JSON.stringify(item))
+        if (!that.strings)
+            item = item[that.options.property]
+        i.find('a').html(that.highlighter(item))
+        return i[0]
+      })
+
+      items.first().addClass('active')
+      this.$menu.html(items)
+      return this
+    }
+
+  , next: function (event) {
+      var active = this.$menu.find('.active').removeClass('active')
+        , next = active.next()
+
+      if (!next.length) {
+        next = $(this.$menu.find('li')[0])
+      }
+
+      next.addClass('active')
+    }
+
+  , prev: function (event) {
+      var active = this.$menu.find('.active').removeClass('active')
+        , prev = active.prev()
+
+      if (!prev.length) {
+        prev = this.$menu.find('li').last()
+      }
+
+      prev.addClass('active')
+    }
+
+  , listen: function () {
+      this.$element
+        .on('blur',     $.proxy(this.blur, this))
+        .on('keypress', $.proxy(this.keypress, this))
+        .on('keyup',    $.proxy(this.keyup, this))
+
+      if ($.browser.webkit || $.browser.msie) {
+        this.$element.on('keydown', $.proxy(this.keypress, this))
+      }
+
+      this.$menu
+        .on('click', $.proxy(this.click, this))
+        .on('mouseenter', 'li', $.proxy(this.mouseenter, this))
+    }
+
+  , keyup: function (e) {
+      switch(e.keyCode) {
+        case 40: // down arrow
+        case 38: // up arrow
+          break
+
+        case 9: // tab
+        case 13: // enter
+          if (!this.shown) return
+          this.select()
+          break
+
+        case 27: // escape
+          if (!this.shown) return
+          this.hide()
+          break
+
+        default:
+          this.lookup()
+      }
+
+      e.stopPropagation()
+      e.preventDefault()
+  }
+
+  , keypress: function (e) {
+      if (!this.shown) return
+
+      switch(e.keyCode) {
+        case 9: // tab
+        case 13: // enter
+        case 27: // escape
+          e.preventDefault()
+          break
+
+        case 38: // up arrow
+          e.preventDefault()
+          this.prev()
+          break
+
+        case 40: // down arrow
+          e.preventDefault()
+          this.next()
+          break
+      }
+
+      e.stopPropagation()
+    }
+
+  , blur: function (e) {
+      var that = this
+      setTimeout(function () { that.hide() }, 150)
+    }
+
+  , click: function (e) {
+      e.stopPropagation()
+      e.preventDefault()
+      this.select()
+    }
+
+  , mouseenter: function (e) {
+      this.$menu.find('.active').removeClass('active')
+      $(e.currentTarget).addClass('active')
+    }
+
+  }
+
+
+  /* TYPEaheadAjax PLUGIN DEFINITION
+   * =========================== */
+
+  $.fn.typeaheadAjax = function ( option ) {
+    return this.each(function () {
+      var $this = $(this)
+        , data = $this.data('typeaheadAjax')
+        , options = typeof option == 'object' && option
+      if (!data) $this.data('typeaheadAjax', (data = new TypeaheadAjax(this, options)))
+      if (typeof option == 'string') data[option]()
+    })
+  }
+
+  $.fn.typeaheadAjax.defaults = {
+    source: []
+  , items: 8
+  , menu: '<ul class="typeahead dropdown-menu"></ul>'
+  , item: '<li><a href="#"></a></li>'
+  , onselect: null
+  , property: 'value'
+  }
+
+  $.fn.typeaheadAjax.Constructor = TypeaheadAjax
+
+
+ /* TYPEaheadAjax DATA-API
+  * ================== */
+
+  $(function () {
+    $('body').on('focus.typeaheadAjax.data-api', '[data-provide="typeaheadAjax"]', function (e) {
+      var $this = $(this)
+      if ($this.data('typeaheadAjax')) return
+      e.preventDefault()
+      $this.typeaheadAjax($this.data())
+    })
+  })
+
+}( window.jQuery );

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,3 +1,3 @@
 module.exports = function (req, res) {
-  res.render('index', { title: 'say wat?' });
+  res.render('index', { title: 'say wat?', layout: 'typeahead-layout' });
 };

--- a/routes/search.js
+++ b/routes/search.js
@@ -11,9 +11,8 @@ module.exports = function (req, res) {
     .populate('_user')
     .run(function (err, results) {
       if (err) { return res.redirect('/error'); }
-      if (results.length === 0) { return res.redirect(url.format({ pathname: '/ask', query: { phrase: req.query.q } })); }
-      
       if (req.accepts('json')) { return res.json(results); }
+      if (results.length === 0) { return res.redirect(url.format({ pathname: '/ask', query: { phrase: req.query.q } })); }
       res.render('search', { title: 'say wat?', results: results, query: req.query.q });
     });
 };

--- a/routes/searchpartial.js
+++ b/routes/searchpartial.js
@@ -1,0 +1,16 @@
+var mongoose = require('mongoose')
+  , url = require('url')
+  , Wat = mongoose.model('Wat')
+  ;
+
+module.exports = function (req, res) {
+  if (!req.query.q || req.query.q.length === 0) { return res.redirect('/'); }
+
+  Wat
+    .$where('this.phrase.indexOf("' + req.query.q + '") != -1').exec(function (err, results) {
+      if (err) { return res.redirect('/error'); }
+      if (req.accepts('json')) { return res.json(results); }
+      if (results.length === 0) { return res.redirect(url.format({ pathname: '/ask', query: { phrase: req.query.q } })); }
+      res.render('search', { title: 'say wat?', results: results, query: req.query.q });
+    });
+};

--- a/views/index.jade
+++ b/views/index.jade
@@ -16,7 +16,7 @@ script(type='text/javascript')
       source: function (typeahead, query) {
         return $.ajax({
           type: "GET",
-          url: '/search', 
+          url: '/searchpartial', 
           contentType: "application/json; charset=utf-8",
           dataType: "json",
           data: { q: query }, 
@@ -24,6 +24,7 @@ script(type='text/javascript')
             return typeahead.process(data);
           }
         });
-      }
+      },
+      property: "phrase"
     });
   });  

--- a/views/index.jade
+++ b/views/index.jade
@@ -7,6 +7,23 @@ div.row-fluid
   div.search
     form(method='GET', action='/search')
       div.span8
-        input(type='text', name='q')
+        input#q(type='text', name='q')
       div.span3
         input.btn(type='submit', value='help!')
+script(type='text/javascript')
+  $(document).ready(function() {
+    $('#q').typeaheadAjax({ 
+      source: function (typeahead, query) {
+        return $.ajax({
+          type: "GET",
+          url: '/search', 
+          contentType: "application/json; charset=utf-8",
+          dataType: "json",
+          data: { q: query }, 
+          success: function (data) {
+            return typeahead.process(data);
+          }
+        });
+      }
+    });
+  });  

--- a/views/index.jade
+++ b/views/index.jade
@@ -7,24 +7,6 @@ div.row-fluid
   div.search
     form(method='GET', action='/search')
       div.span8
-        input#q(type='text', name='q')
+        input#typeahead(type='text', name='q')
       div.span3
         input.btn(type='submit', value='help!')
-script(type='text/javascript')
-  $(document).ready(function() {
-    $('#q').typeaheadAjax({ 
-      source: function (typeahead, query) {
-        return $.ajax({
-          type: "GET",
-          url: '/searchpartial', 
-          contentType: "application/json; charset=utf-8",
-          dataType: "json",
-          data: { q: query }, 
-          success: function (data) {
-            return typeahead.process(data);
-          }
-        });
-      },
-      property: "phrase"
-    });
-  });  

--- a/views/layout.jade
+++ b/views/layout.jade
@@ -7,9 +7,6 @@ html
     link(rel='stylesheet', 
     href='http://fonts.googleapis.com/css?family=Cabin+Condensed:400,500,600,700')
     link(rel='stylesheet', href='/stylesheets/app/main.css')
-    script(type='text/javascript', src='/scripts/jquery-1.7.2.min.js')
-    script(type='text/javascript', src='/scripts/bootstrap.min.js')
-    script(type='text/javascript', src='/scripts/typeaheadajax.js')
   body
     div.container
       div.container-fluid
@@ -22,3 +19,6 @@ html
                   a(href='/') Home
                 li
                   a(href='/about') About
+  block footer
+    script(type='text/javascript', src='/scripts/jquery-1.7.2.min.js')
+    script(type='text/javascript', src='/scripts/bootstrap.min.js')

--- a/views/layout.jade
+++ b/views/layout.jade
@@ -7,6 +7,9 @@ html
     link(rel='stylesheet', 
     href='http://fonts.googleapis.com/css?family=Cabin+Condensed:400,500,600,700')
     link(rel='stylesheet', href='/stylesheets/app/main.css')
+    script(type='text/javascript', src='/scripts/jquery-1.7.2.min.js')
+    script(type='text/javascript', src='/scripts/bootstrap.min.js')
+    script(type='text/javascript', src='/scripts/typeaheadajax.js')
   body
     div.container
       div.container-fluid
@@ -19,5 +22,3 @@ html
                   a(href='/') Home
                 li
                   a(href='/about') About
-    script(type='text/javascript', src='/scripts/jquery-1.7.2.min.js')
-    script(type='text/javascript', src='/scripts/bootstrap.min.js')

--- a/views/typeahead-layout.jade
+++ b/views/typeahead-layout.jade
@@ -1,0 +1,22 @@
+extends layout
+
+block append footer
+  script(type='text/javascript', src='/scripts/typeaheadajax.js')  
+  script(type='text/javascript')
+    $(document).ready(function() {
+      $('#typeahead').typeaheadAjax({ 
+        source: function (typeahead, query) {
+          return $.ajax({
+            type: "GET",
+            url: '/searchpartial', 
+            contentType: "application/json; charset=utf-8",
+            dataType: "json",
+            data: { q: query }, 
+            success: function (data) {
+              return typeahead.process(data);
+            }
+          });
+        },
+        property: "phrase"
+      });
+    });  


### PR DESCRIPTION
Some notes:

There didn't seem to be a complete way to put data in, so I used this to test it (from the search.js route).
      var tests = ["test", "test2", "test3", "typeahead", "typeahead2"];
      if (req.accepts('json')) { return res.json(tests); }
- I put the json return "if" before the 0 results "if" in search.js because if there was 0 results it was returning a html page.
- I moved the jquery up above the body in the layout because you couldn't use jquery before it was defined - if you want to point out how it should go, then I'm happy to adjust
- I wanted to use the built in bootstrap version of typeahead but it doesn't use ajax, so I used an adjusted version sourced https://gist.github.com/1891669 - other thoughts were just to use the jquery ui but after some playing I got it to work.
